### PR TITLE
Fix Db2tcl library load issues under Python

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -206,7 +206,7 @@ LTCOMPILE = $(LIBTOOL) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) \
 	$(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 CCLD = $(CC)
 LINK = $(LIBTOOL) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
-	$(AM_LDFLAGS) $(LDFLAGS) -o $@
+	$(AM_LDFLAGS) $(LDFLAGS) $(db2tclsh_LDFLAGS) -o $@
 DIST_SOURCES = $(libdb2tcl_la_SOURCES) $(db2tclsh_SOURCES) \
 	$(db2wish_SOURCES)
 HEADERS = $(noinst_HEADERS)

--- a/src/db2tcl.c
+++ b/src/db2tcl.c
@@ -88,7 +88,7 @@ Tcl_Interp * interp;
     Tcl_CreateObjCommand (interp, "db2_test", Db2_test,
                        (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
 
-    Tcl_PkgProvide (interp, "db2tcl", "2.0");
+    Tcl_PkgProvide (interp, "db2tcl", "2.0.1");
 
     return TCL_OK;
 }


### PR DESCRIPTION
Fix enables db2tcl to load successfully with Tcl running under Python. 
```
HammerDB-4.7$ ./hammerdbcli py
HammerDB CLI v4.7
Copyright (C) 2003-2023 Steve Shaw
Type "help()" for a list of commands
hammerdb>>>tclpy.eval('package require db2tcl')
'2.0.1'
```
Although windows was not affected, have checked windows build to ensure no negative impacts from code changes.
```
C:\HammerDB-master\Build\BawtBuild\vs2022\x64\Release\Distribution\HammerDB-4.7>hammerdbcli py
HammerDB CLI v4.7
Copyright (C) 2003-2023 Steve Shaw
Type "help()" for a list of commands
hammerdb>>>tclpy.eval('package require db2tcl')
'2.0.1'
```
updated code already in-place for build from source but will not make HammerDB v4.7

The version number mismatch 2.0.1 / 2.0 produced a warning only if loading the library directly which HammerDB doesn't do (always uses package require), but corrected that as well. 