### PR TITLE
Update db2tcl for Tcl 9

### DIFF
--- a/configure
+++ b/configure
@@ -423,8 +423,8 @@ SHELL=${CONFIG_SHELL-/bin/sh}
 PACKAGE_NAME='db2tcl'
 PACKAGE_LIB='libdb2tcl.so'
 PACKAGE_TARNAME='db2tcl'
-PACKAGE_VERSION='2.0.1'
-PACKAGE_STRING='db2tcl 2.0.1'
+PACKAGE_VERSION='2.0.1.1'
+PACKAGE_STRING='db2tcl 2.0.1.1'
 PACKAGE_BUGREPORT='sergeybe@users.sourceforge.net'
 
 ac_unique_file="config.h.in"

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -2,4 +2,4 @@
 # Tcl package index file
 #
 package ifneeded db2tcl @PACKAGE_VERSION@ \
-    [list load [ file join $dir @PACKAGE_LIB@ ] @PACKAGE_NAME@]
+    [list load [ file join $dir @PACKAGE_LIB@ ] [ string totitle @PACKAGE_NAME@ ]]

--- a/src/db2tcl.c
+++ b/src/db2tcl.c
@@ -7,7 +7,7 @@
    #include <tk.h>
    #define PACKAGE "db2tcl"
 #endif
-   #define PACKAGE_VERSION "2.0.1"
+   #define PACKAGE_VERSION "2.0.1.1"
 
 #ifdef _WINDOWS
 __declspec( dllexport )
@@ -15,9 +15,9 @@ __declspec( dllexport )
 int Db2tcl_Init(interp)
 Tcl_Interp * interp;
 {
-	 if (Tcl_InitStubs(interp, "8.6", 0) == NULL)
+	 if (Tcl_InitStubs(interp, "8.6-", 0) == NULL)
     return TCL_ERROR;
-  if (Tcl_PkgRequire(interp, "Tcl", "8.6", 0) == NULL)
+  if (Tcl_PkgRequire(interp, "Tcl", "8.6-", 0) == NULL)
     return TCL_ERROR;
   if (Tcl_PkgProvide(interp, "db2tcl" , PACKAGE_VERSION) != TCL_OK)
     return TCL_ERROR;
@@ -88,7 +88,7 @@ Tcl_Interp * interp;
     Tcl_CreateObjCommand (interp, "db2_test", Db2_test,
                        (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
 
-    Tcl_PkgProvide (interp, "db2tcl", "2.0.1");
+    Tcl_PkgProvide (interp, "db2tcl", "2.0.1.1");
 
     return TCL_OK;
 }

--- a/src/db2tcl.c
+++ b/src/db2tcl.c
@@ -5,8 +5,8 @@
 #ifdef _WINDOWS
    #include <windows.h>
    #include <tk.h>
-   #define PACKAGE "db2tcl"
 #endif
+   #define PACKAGE "db2tcl"
    #define PACKAGE_VERSION "2.0.1.1"
 
 #ifdef _WINDOWS
@@ -88,7 +88,7 @@ Tcl_Interp * interp;
     Tcl_CreateObjCommand (interp, "db2_test", Db2_test,
                        (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
 
-    Tcl_PkgProvide (interp, "db2tcl", "2.0.1.1");
+    Tcl_PkgProvide (interp, PACKAGE, PACKAGE_VERSION);
 
     return TCL_OK;
 }

--- a/src/db2tcl.c
+++ b/src/db2tcl.c
@@ -6,8 +6,8 @@
    #include <windows.h>
    #include <tk.h>
 #endif
-   #define PACKAGE "db2tcl"
-   #define PACKAGE_VERSION "2.0.1.1"
+#define PACKAGE "db2tcl"
+#define PACKAGE_VERSION "2.0.1.1"
 
 #ifdef _WINDOWS
 __declspec( dllexport )
@@ -15,11 +15,11 @@ __declspec( dllexport )
 int Db2tcl_Init(interp)
 Tcl_Interp * interp;
 {
-	 if (Tcl_InitStubs(interp, "8.6-", 0) == NULL)
+  if (Tcl_InitStubs(interp, "8.6-", 0) == NULL)
     return TCL_ERROR;
   if (Tcl_PkgRequire(interp, "Tcl", "8.6-", 0) == NULL)
     return TCL_ERROR;
-  if (Tcl_PkgProvide(interp, "db2tcl" , PACKAGE_VERSION) != TCL_OK)
+  if (Tcl_PkgProvide(interp, PACKAGE, PACKAGE_VERSION) != TCL_OK)
     return TCL_ERROR;
 
     /* On Windows initialize default channels to prevent incorrect naming of channels */
@@ -87,8 +87,6 @@ Tcl_Interp * interp;
 
     Tcl_CreateObjCommand (interp, "db2_test", Db2_test,
                        (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
-
-    Tcl_PkgProvide (interp, PACKAGE, PACKAGE_VERSION);
 
     return TCL_OK;
 }

--- a/src/db2tclcmds.c
+++ b/src/db2tclcmds.c
@@ -1,7 +1,6 @@
 /* $Id$ */
 
 #include "db2tclcmds.h"
-/*#include <sqle819a.h>*/ /* For sqlecrea(): struct sqledbdesc: sqldbudc sqle_819_500 */
 #include <sqlcli1.h>
 #include <sqlenv.h>
 #include <string.h>

--- a/src/db2tclcmds.c
+++ b/src/db2tclcmds.c
@@ -1,9 +1,18 @@
 /* $Id$ */
 
 #include "db2tclcmds.h"
+/*#include <sqle819a.h>*/ /* For sqlecrea(): struct sqledbdesc: sqldbudc sqle_819_500 */
 #include <sqlcli1.h>
 #include <sqlenv.h>
 #include <string.h>
+
+#ifndef TCL_SIZE_MAX
+typedef int Tcl_Size;
+# define Tcl_GetSizeIntFromObj Tcl_GetIntFromObj
+# define Tcl_NewSizeIntObj Tcl_NewIntObj
+# define TCL_SIZE_MAX      INT_MAX
+# define TCL_SIZE_MODIFIER ""
+#endif
 
 static SQLHANDLE henv = SQL_NULL_HANDLE;
 static int num_connect = 0;
@@ -54,7 +63,7 @@ int Db2InputProc (ClientData cData, char *buf, int bufSize, int *errorCodePtr)
     return 0;
 }
 
-int Db2OutputProc (ClientData cData, CONST84 char *buf, int bufSize,
+int Db2OutputProc (ClientData cData, const char *buf, int bufSize,
 		   int *errorCodePtr)
 {
     Db2Connection *conn;
@@ -92,7 +101,7 @@ Tcl_ChannelType Db2_ConnType = {
 */
 
 int Db2_connect (ClientData cData, Tcl_Interp * interp, int argc,
-		 CONST84 char *argv[])
+		 const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -192,7 +201,7 @@ int Db2_connect (ClientData cData, Tcl_Interp * interp, int argc,
 */
 
 int Db2_disconnect (ClientData cData, Tcl_Interp * interp, int argc,
-		    CONST84 char *argv[])
+		    const char *argv[])
 {
     Tcl_Channel conn_channel;
     char id[MAX_ID_LENGTH + 1];
@@ -228,7 +237,7 @@ int Db2_disconnect (ClientData cData, Tcl_Interp * interp, int argc,
    Return database handle
 */
 
-int Db2_create_db (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_create_db (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     struct sqlca sqlca;
     char dbName[SQL_DBNAME_SZ + 1];
@@ -292,7 +301,7 @@ int Db2_create_db (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char
    Return execution results
 */
 
-int Db2_drop_db (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_drop_db (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Db2Connection *conn;
     char dbname[SQL_ALIAS_SZ + 1];
@@ -332,7 +341,7 @@ int Db2_drop_db (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *
    Return execution results
 */
 
-int Db2_force_off (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_force_off (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Db2Connection *conn;
     struct sqlca sqlca;
@@ -367,7 +376,7 @@ int Db2_force_off (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char
     Return database handle
 */
 
-int Db2_exec_direct (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_exec_direct (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -415,7 +424,7 @@ int Db2_exec_direct (ClientData cData, Tcl_Interp * interp, int argc, CONST84 ch
     }
 
     /* Return result by template db2sqlX.Y */
-    snprintf (buff, MAX_ID_LENGTH, "%s.%d", conn->id, SQL_NULL_HANDLE);
+    snprintf (buff, MAX_ID_LENGTH, "%s.%ld", conn->id, SQL_NULL_HANDLE);
     Tcl_AppendResult (interp, buff, (char *)NULL);
 
     conn->rc = SQLFreeHandle (SQL_HANDLE_STMT, hstmt);
@@ -441,7 +450,7 @@ int Db2_exec_direct (ClientData cData, Tcl_Interp * interp, int argc, CONST84 ch
     Return database handle
 */
 
-int Db2_select_direct (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_select_direct (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -517,7 +526,7 @@ int Db2_select_direct (ClientData cData, Tcl_Interp * interp, int argc, CONST84 
     Return database handle
 */
 
-int Db2_prepare (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_prepare (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -594,7 +603,7 @@ int Db2_prepare (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *
 
 
 int Db2_bind_param (ClientData cData, Tcl_Interp * interp, int argc,
-                  CONST84 char *argv[])
+                  const char *argv[])
 {
     int i = 1;
     Tcl_Channel conn_channel;
@@ -603,8 +612,8 @@ int Db2_bind_param (ClientData cData, Tcl_Interp * interp, int argc,
     SQLHANDLE hdbc, hstmt;
     SQLLEN ival = SQL_NULL_DATA;
     short num_params;
-    int nparam;
-    char **paramList;
+    Tcl_Size nparam;
+    const char **paramList;
 
 if (argc != 3)
     {
@@ -694,7 +703,7 @@ if (argc != 3)
 
 
 int Db2_bind_exec (ClientData cData, Tcl_Interp * interp, int argc,
-                  CONST84 char *argv[])
+                  const char *argv[])
 {
     int i = 1;
     Tcl_Channel conn_channel;
@@ -704,8 +713,8 @@ int Db2_bind_exec (ClientData cData, Tcl_Interp * interp, int argc,
     SQLHANDLE hdbc, hstmt;
     SQLLEN ival = SQL_NULL_DATA;
     short num_params;
-    int nparam;
-    char **paramList;
+    Tcl_Size nparam;
+    const char **paramList;
 
 if (argc != 3)
     {
@@ -797,7 +806,7 @@ if (argc != 3)
     }
 
     /* Return result by template db2sqlX.Y */
-    snprintf (buff, MAX_ID_LENGTH, "%s.%d", conn->id, SQL_NULL_HANDLE);
+    snprintf (buff, MAX_ID_LENGTH, "%s.%ld", conn->id, SQL_NULL_HANDLE);
     Tcl_AppendResult (interp, buff, (char *)NULL);
     if (paramList) ckfree((char *) paramList);
     return TCL_OK;
@@ -810,7 +819,7 @@ if (argc != 3)
     Return database handle
 */
 
-int Db2_exec_prepared (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_exec_prepared (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -871,7 +880,7 @@ int Db2_exec_prepared (ClientData cData, Tcl_Interp * interp, int argc, CONST84 
     }
 
     /* Return result by template db2sqlX.Y */
-    snprintf (buff, MAX_ID_LENGTH, "%s.%d", conn->id, SQL_NULL_HANDLE);
+    snprintf (buff, MAX_ID_LENGTH, "%s.%ld", conn->id, SQL_NULL_HANDLE);
     Tcl_AppendResult (interp, buff, (char *)NULL);
 
     return TCL_OK;
@@ -884,7 +893,7 @@ int Db2_exec_prepared (ClientData cData, Tcl_Interp * interp, int argc, CONST84 
     Return database handle
 */
 
-int Db2_select_prepared (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_select_prepared (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -973,7 +982,7 @@ int Db2_select_prepared (ClientData cData, Tcl_Interp * interp, int argc, CONST8
 */
 
 int Db2_fetchrow (ClientData cData, Tcl_Interp * interp, int argc,
-		  CONST84 char *argv[])
+		  const char *argv[])
 {
     int i = 1;
     int num_col = 0;
@@ -1091,7 +1100,7 @@ int Db2_fetchrow (ClientData cData, Tcl_Interp * interp, int argc,
     db2_finish handle
 */
 
-int Db2_finish (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_finish (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -1147,7 +1156,7 @@ int Db2_finish (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *a
     Return number of columns in query
 */
 int Db2_getnumrows (ClientData cData, Tcl_Interp * interp, int argc,
-                    CONST84 char *argv[])
+                    const char *argv[])
 {
     SQLHANDLE hdbc, hstmt;
     short num_fields;
@@ -1172,7 +1181,7 @@ int Db2_getnumrows (ClientData cData, Tcl_Interp * interp, int argc,
 
 */
 
-int Db2_begin_transaction (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_begin_transaction (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -1220,7 +1229,7 @@ int Db2_begin_transaction (ClientData cData, Tcl_Interp * interp, int argc, CONS
 
 */
 
-int Db2_commit_transaction (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_commit_transaction (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -1281,7 +1290,7 @@ int Db2_commit_transaction (ClientData cData, Tcl_Interp * interp, int argc, CON
 
 */
 
-int Db2_rollback_transaction (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_rollback_transaction (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     Tcl_Channel conn_channel;
     Db2Connection *conn;
@@ -1339,7 +1348,7 @@ int Db2_rollback_transaction (ClientData cData, Tcl_Interp * interp, int argc, C
     db2tcl super command
 */
 
-int Db2_db2 (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv[])
+int Db2_db2 (ClientData cData, Tcl_Interp * interp, int argc, const char *argv[])
 {
     if (argc < 2 || argv[1] == NULL )
     {
@@ -1412,7 +1421,7 @@ int Db2_db2 (ClientData cData, Tcl_Interp * interp, int argc, CONST84 char *argv
 
 /* This function only for test */
 
-int Db2_test (ClientData clientData, Tcl_Interp * interp, int objc, struct Tcl_Obj * CONST * objv)
+int Db2_test (ClientData clientData, Tcl_Interp * interp, int objc, struct Tcl_Obj * const * objv)
 {
     int i;
 

--- a/src/db2tclcmds.h
+++ b/src/db2tclcmds.h
@@ -18,10 +18,6 @@
 #define MAX_COLUMNS    255
 #define MAX_ID_LENGTH  255
 
-#ifndef CONST84
-#define CONST84
-#endif
-
 typedef struct FieldBuffer { 
   /* description of the field */
   SQLSMALLINT dbtype;
@@ -64,119 +60,119 @@ extern int Db2_connect(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_disconnect(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_create_db(
 		ClientData cData,
 		Tcl_Interp *interp,
 		int argc,
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_drop_db(
 		ClientData cData,
 		Tcl_Interp *interp,
 		int argc,
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_force_off(
 		ClientData cData,
 		Tcl_Interp *interp,
 		int argc,
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_exec_direct(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_exec_prepared(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_select_direct(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_select_prepared(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_prepare(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_bind_param(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_bind_exec(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_finish(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_fetchrow(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_getnumrows(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_begin_transaction(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_commit_transaction(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_rollback_transaction(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_db2(
 		ClientData cData, 
 		Tcl_Interp *interp, 
 		int argc, 
-		CONST84 char *argv[]);
+		const char *argv[]);
 
 extern int Db2_test (ClientData clientData,
                      Tcl_Interp * interp,
                      int objc, 
-		     struct Tcl_Obj * CONST * objv);
+		     struct Tcl_Obj * const * objv);
 
 #endif	 /* DB2TCLCMDS_H */

--- a/src/db2tclsh.c
+++ b/src/db2tclsh.c
@@ -20,6 +20,10 @@
 #include "tcl.h"
 #include "db2tcl.h"
 
+#if TCL_MAJOR_VERSION >= 9
+int Tcl_AppInit(Tcl_Interp *);
+#endif
+
 /*
  * The following variable is a special hack that is needed in order for
  * Sun shared libraries to be used for Tcl.

--- a/src/db2wish.c
+++ b/src/db2wish.c
@@ -16,6 +16,10 @@
 #include "tk.h"
 #include "db2tcl.h"
 
+#if TK_MAJOR_VERSION >= 9
+int Tcl_AppInit(Tcl_Interp *);
+#endif
+
 /*
  * The following variable is a special hack that is needed in order for
  * Sun shared libraries to be used for Tcl.

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -1,7 +1,7 @@
 # Makefile.vc
 
-PGTCL_VERSION = 2.0.1
-DLL_VERSION = 201
+DB2TCL_VERSION = 2.0.1.1
+DLL_VERSION = 2011
 
 PROJECT = db2tcl$(DLL_VERSION)
 !include "rules.vc"
@@ -20,7 +20,7 @@ CP      = copy
 RM      = del
 
 PACKAGE_NAME	= db2tcl
-PACKAGE_VERSION	= 2.0.1
+PACKAGE_VERSION	= 2.0.1.1
 DLL = libdb2tcl.dll
 
 lflags = /NOLOGO /MACHINE:$(MACHINE) /LIBPATH:"$(TCL_LIBRARY)"
@@ -29,9 +29,9 @@ DLLENTRY = @12
 dlllflags = $(lflags) -entry:_DllMainCRTStartup -dll
 
 
-CLFLAGS = /c -Ob2 -favor:blend /MT /W3 /nologo /D_CRT_SECURE_NO_WARNINGS -DUSE_TCL_STUBS -DPACKAGE_NAME=\"db2tcl\" -DPACKAGE_VERSION=\"2.0.1\"
+CLFLAGS = /c -Ob2 -favor:blend /MT /W3 /nologo /D_CRT_SECURE_NO_WARNINGS -DUSE_TCL_STUBS -DPACKAGE_NAME=\"db2tcl\" -DPACKAGE_VERSION=\"2.0.1.1\"
 
-baselibs   =  "$(TCL_LIBRARY)/tcl86t.lib" "$(TCL_LIBRARY)/tclstub86.lib" "$(TK_LIBRARY)/tk86t.lib" "$(TK_LIBRARY)/tkstub86.lib" "$(LIBDIR)/db2cli.lib" "$(LIBDIR)/db2api.lib"
+baselibs   =  "$(TCL_LIBRARY)/tcl90.lib" "$(TCL_LIBRARY)/tclstub.lib" "$(TK_LIBRARY)/tcl9tk90.lib" "$(TK_LIBRARY)/tkstub.lib" "$(LIBDIR)/db2cli.lib" "$(LIBDIR)/db2api.lib"
 
 DIR_SRC = ..\src
 


### PR DESCRIPTION
PR updates db2tcl to build against the new Tcl/TK 9 as well as the older version 8